### PR TITLE
Fix encoding in sentiment analysis request

### DIFF
--- a/static/mywebscript.js
+++ b/static/mywebscript.js
@@ -1,5 +1,6 @@
-let RunSentimentAnalysis = ()=>{
-    textToAnalyze = document.getElementById("textToAnalyze").value;
+let RunSentimentAnalysis = () => {
+    const textToAnalyze = document.getElementById("textToAnalyze").value;
+    const encodedText = encodeURIComponent(textToAnalyze);
 
     let xhttp = new XMLHttpRequest();
     xhttp.onreadystatechange = function() {
@@ -7,6 +8,6 @@ let RunSentimentAnalysis = ()=>{
             document.getElementById("system_response").innerHTML = xhttp.responseText;
         }
     };
-    xhttp.open("GET", "emotionDetector?textToAnalyze"+"="+textToAnalyze, true);
+    xhttp.open("GET", "emotionDetector?textToAnalyze=" + encodedText, true);
     xhttp.send();
 }


### PR DESCRIPTION
## Summary
- ensure user input is properly URL encoded when making the GET request

## Testing
- `npm test` *(fails: no package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685bbb7a4208832787e814162ef4e038